### PR TITLE
Fix: Prevent Build Errors on Non-Windows Platforms by Skipping Compilation in `binding.gyp`

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,26 +1,30 @@
 {
     "targets": [{
         "target_name": "winVerifyTrust",
-        "cflags!": [ "-fno-exceptions" ],
-        "cflags_cc!": [ "-fno-exceptions" ],
-        "sources": [
-            "lib/src/napi.cpp",
-            "lib/src/verifyTrust.cpp",
-            "lib/src/certificate.cpp",
-            "lib/src/string.cpp"
-        ],
-        "msvs_settings": {
-          "VCCLCompilerTool": {
-             "ExceptionHandling": 1,
-             "AdditionalOptions": []
-          }
-         },
-        "include_dirs": [
-            "<!(node -p \"require('node-addon-api').include_dir\")"
-        ],
-        "dependencies": [
-            "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_maybe"
-        ],
-        "defines": [ "NODE_ADDON_API_DISABLE_DEPRECATED" ]
+        "conditions": [
+            ["OS=='win'", {
+                "cflags!": [ "-fno-exceptions" ],
+                "cflags_cc!": [ "-fno-exceptions" ],
+                "sources": [
+                    "lib/src/napi.cpp",
+                    "lib/src/verifyTrust.cpp",
+                    "lib/src/certificate.cpp",
+                    "lib/src/string.cpp"
+                ],
+                "msvs_settings": {
+                    "VCCLCompilerTool": {
+                        "ExceptionHandling": 1,
+                        "AdditionalOptions": []
+                    }
+                },
+                "include_dirs": [
+                    "<!(node -p \"require('node-addon-api').include_dir\")"
+                ],
+                "dependencies": [
+                    "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_maybe"
+                ],
+                "defines": [ "NODE_ADDON_API_DISABLE_DEPRECATED" ]
+            }]
+        ]
     }]
 }


### PR DESCRIPTION
### Background

I’m working on a cross-platform project (Windows, Linux, macOS) that uses `@xan105/win-verify-trust` only for Windows builds. However, listing this package as a dependency in `package.json` breaks the build on Linux/macOS with the following error:

```
In file included from ../lib/src/napi.cpp:8:
../lib/src/verifyTrust.h:4:10: fatal error: windows.h: No such file or directory
    4 | #include <windows.h>
      |          ^~~~~~~~~~~
```

Even though the package is not used on Linux/macOS, `node-gyp` still attempts to compile the native module, causing `npm install` to fail.

### Solution

This PR modifies `binding.gyp` to **conditionally compile only on Windows** (`OS=='win'`).
- On Windows, everything works as before.
- On Linux/macOS, the package installs successfully but skips compilation.

This ensures the package does not block `npm install` on non-Windows platforms while remaining fully functional on Windows.