### PR TITLE
Add '.cat' to allowed file extensions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ async function shouldValidFile(filePath){
 
   shouldStringNotEmpty(filePath);
 
-  const allowed = [ ".exe", ".cab", ".dll", ".ocx", ".msi", ".msix", ".xpi", ".ps1", ".node" ];
+  const allowed = [ ".exe", ".cab", ".cat", ".dll", ".ocx", ".msi", ".msix", ".xpi", ".ps1", ".node" ];
 
   if (!allowed.includes(extname(filePath)))
     throw new Failure(`Accepted file types are: ${allowed.join(",")}`, 1);


### PR DESCRIPTION
It would be helpful is this library supported [catalog files](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/catalog-files), i.e. `.cat` files.